### PR TITLE
Adjust types to match

### DIFF
--- a/templates/crawlspace.d.ts
+++ b/templates/crawlspace.d.ts
@@ -39,8 +39,8 @@ interface Crawler {
     }) => Promise<Record<string, any>[]>;
   }) => URLRequest[] | Promise<URLRequest[]>;
   onResponse: (handlerProps: {
-    $: <T>(querySelector: string) => HTMLElement | null;
-    $$: <T>(querySelector: string) => Array<T>;
+    $: <T>(querySelector: string) => Element&T | null;
+    $$: <T>(querySelector: string) => Array<Element&T>;
     ai: {
       embed: (
         $el: HTMLElement | string | Array<HTMLElement | string>,
@@ -74,7 +74,7 @@ interface Crawler {
       reqs: URLRequest | HTMLElement | Array<URLRequest | HTMLElement>,
     ) => void;
     env: Record<string, string>;
-    getMarkdown: (querySelector?: string) => string;
+    getMarkdown: (element?: Element) => string;
     json?: any;
     request: Request;
     response: Response;


### PR DESCRIPTION
As I've been testing this out I noticed a couple types that could be adjusted:

- `Crawler.getMarkdown` expects an `Element` and not a string
- `Crawler.$` and `Crawler.$` will always return subtypes of `Element`. This still allows things like `$$<HTMLAnchorElement>('a')`