### PR TITLE
Avoid reusing stale xml / json values

### DIFF
--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -152,6 +152,8 @@ export default async function dev() {
       const end = Date.now();
       spinner.stop();
 
+      let xml = undefined;
+      let json = undefined;
       let html = "";
       let $ = (qs: string) => <HTMLElement | null>null;
       let $$ = (qs: string) => <NodeList | never[]>[];
@@ -167,13 +169,13 @@ export default async function dev() {
           return htmlToMarkdown(value!, nhm);
         };
       } else if (contentType.startsWith("application/json")) {
-        var json = await response.json();
+        json = await response.json();
       } else if (
         contentType.startsWith("text/xml") ||
         contentType.startsWith("application/xml")
       ) {
         const parser = new XMLParser();
-        var xml = parser.parse(await response.text());
+        xml = parser.parse(await response.text());
       } else {
         // TODO: should we do something here?
       }


### PR DESCRIPTION
The `var` gets hoisted to the top of the function, so these variables weren't being unset on each loop. This change fixes that by setting them to undefined earlier in the loop