### PR TITLE
Use the new JSON mode available in Workers AI

### DIFF
--- a/src/utils/ai.ts
+++ b/src/utils/ai.ts
@@ -6,16 +6,6 @@ import { zodToJsonSchema } from "zod-to-json-schema";
 import api from "./api";
 import { htmlToMarkdown } from "./markdown";
 
-type Tool = {
-  name: string;
-  description: string;
-  parameters: {
-    type: string;
-    properties: Record<string, { type: string; description: string }>;
-    required: string[];
-  };
-};
-
 type ExtractionOptions = {
   model: "meta/llama-3.1-8b" | "meta/llama-3.3-70b";
   instruction: string;
@@ -34,13 +24,8 @@ export default function genAi({ nhm }: { nhm: NodeHtmlMarkdown }) {
   return {
     async extract($el: HTMLElement | string, opts: ExtractionOptions) {
       const text = $el instanceof HTMLElement ? htmlToMarkdown($el, nhm) : $el;
-      const parameters = zodToJsonSchema(opts.schema, "parameters");
-      const tool = {
-        name: "dataExtractor",
-        description: "Extract data that conforms to the provided schema",
-        ...parameters.definitions,
-      } as Tool;
-      const options = { ...opts, tool };
+      const schema = zodToJsonSchema(opts.schema, "json_schema").definitions;
+      const options = { ...opts, schema };
       const response = await api("/v1/cli/ai/extract", {
         method: "POST",
         body: JSON.stringify({ corpus: text, options }),


### PR DESCRIPTION
This PR enables the new [JSON mode](https://blog.cloudflare.com/build-ai-agents-on-cloudflare/#json-mode-longer-context-windows-and-improved-tool-calling-in-workers-ai) that came out a few days ago for the `ai.extract()` method. Previously, JSON extraction was done via a tool call, which didn't produce accurate JSON 100% of the time. 

https://developers.cloudflare.com/workers-ai/json-mode/

The corresponding PR for the API has already been merged and deployed. 
